### PR TITLE
Add example-variants template for commonly confused words

### DIFF
--- a/skills/daydream-dictation/example-variants.md
+++ b/skills/daydream-dictation/example-variants.md
@@ -1,0 +1,32 @@
+# Voice Dictation Variants — Example Template
+
+This file shows the format for listing words your voice dictation software commonly confuses. Create your own file at `.claude/dd-variants.md` in your repository root. Claude will check it during dictation sessions and silently substitute the correct word when it sees a listed variant.
+
+You can also create multiple files matching `.claude/dd-*.md` if you want to organize variants by topic.
+
+## Format
+
+Each section has a heading with the correct word/phrase, followed by a list of common mis-transcriptions:
+
+```markdown
+# Voice Dictation Variants — "Correct Phrase"
+
+The user's voice dictation software frequently misspells "Correct Phrase". When any of these appear in a prompt, treat them as "Correct Phrase":
+
+- Misspelling One
+- Misspelling Two
+- Misspelling Three
+```
+
+## Example
+
+```markdown
+# Voice Dictation Variants — "Kubernetes"
+
+- Cooper Netties
+- Kuber Netties
+- Cooper net ease
+- Cube er net ease
+```
+
+Add your own entries based on words your dictation software consistently gets wrong. The more specific the list, the better Claude can clean up your transcriptions.


### PR DESCRIPTION
Provides a format template showing users how to create their own .claude/dd-variants.md file for voice dictation corrections.