### PR TITLE
Improve TODO Document section with source tracing

### DIFF
--- a/skills/daydream-dictation/SKILL.md
+++ b/skills/daydream-dictation/SKILL.md
@@ -146,21 +146,26 @@ The Daydream document doesn't need every piece of information about the design i
 
 ## The TODO Document
 
-The TODO document tracks outstanding work that comes up during dictation, responses, or review. Each one should have a status tracked and should be marked complete when finished.
+The TODO document (`TODO-<Slug>.md`) tracks outstanding work that comes up during dictation, responses, or review. Each item should have a status and should be marked complete when finished. The TODO document is the canonical list — inline references in the Daydream doc or other files are just pointers back here.
+
+Add TODO items when:
+- The user flags something during Phase 1 ("note to come back to this")
+- Gap analysis surfaces open questions (Q2)
+- PR review comments identify work to defer
 
 Here's an example format:
 
 ```markdown
 ## Pending
 
-- [ ] Define the networking protocol for multiplayer sessions
-- [ ] Decide on a save file format — binary vs JSON vs SQLite
-- [ ] Add error handling for when the server is unreachable
+- [ ] Define the networking protocol for multiplayer sessions *(Phase 1 dictation)*
+- [ ] Decide on a save file format — binary vs JSON vs SQLite *(gap analysis Q4)*
+- [ ] Add error handling for when the server is unreachable *(PR #3 review)*
 
 ## Complete
 
-- [x] Write the initial project overview
-- [x] Document the three core gameplay loops
+- [x] Write the initial project overview *(Phase 1 dictation)*
+- [x] Document the three core gameplay loops *(Phase 1 dictation)*
 ```
 
 ---

--- a/skills/daydream-dictation/SKILL.md
+++ b/skills/daydream-dictation/SKILL.md
@@ -148,12 +148,7 @@ The Daydream document doesn't need every piece of information about the design i
 
 The TODO document (`TODO-<Slug>.md`) tracks outstanding work that comes up during dictation, responses, or review. Each item should have a status and should be marked complete when finished. The TODO document is the canonical list — inline references in the Daydream doc or other files are just pointers back here.
 
-Add TODO items when:
-- The user flags something during Phase 1 ("note to come back to this")
-- Gap analysis surfaces open questions (Q2)
-- PR review comments identify work to defer
-
-Here's an example format:
+Here's an example format that includes a source of when the TODO came up:
 
 ```markdown
 ## Pending


### PR DESCRIPTION
## Summary
- Clarify TODO doc is canonical; inline references are pointers
- List when to add TODO items (Phase 1 flags, gap analysis Q2, PR review)
- Add source annotations to example items (e.g., *Phase 1 dictation*, *gap analysis Q4*)

## Test plan
- [ ] Example format renders correctly in markdown
- [ ] Source annotations are clear without being noisy

🤖 Generated with [Claude Code](https://claude.com/claude-code)