### PR TITLE
Update LICENSE copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Ecnassianer
+Copyright (c) 2026 Ecnassianer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update copyright year from 2025 to 2026

## Test plan
- [x] One-line change, visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)