### PR TITLE
Add header to Prompts-ddMetadiscussion on first creation

### DIFF
--- a/hooks/dd_log_prompt.py
+++ b/hooks/dd_log_prompt.py
@@ -72,6 +72,9 @@ def main() -> None:
 
     if prompts_doc is None:
         prompts_doc = os.path.join(repo_root, "Prompts-ddMetadiscussion")
+        if not os.path.isfile(prompts_doc):
+            with open(prompts_doc, "w", encoding="utf-8") as f:
+                f.write("# Prompts \u2014 ddMetadiscussion\n\n---\n\n")
 
     # Append numbered entry
     entry_num = next_entry_number(prompts_doc)


### PR DESCRIPTION
## Summary
- When Prompts-ddMetadiscussion is created for the first time, write the standard header before appending the first entry
- Matches the format used by ensure_project_files for project Prompts documents

## Test plan
- [x] All 7 log prompt integration tests pass