### PR TITLE
Add /dictate-daydream alias skill

### DIFF
--- a/skills/dictate-daydream/SKILL.md
+++ b/skills/dictate-daydream/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: dictate-daydream
+description: Alias for /daydream-dictation. Starts a Daydream Dictation session.
+argument-hint: "[project name]"
+version: 0.1.0
+---
+
+# Dictate Daydream
+
+This is an alias for `/daydream-dictation`. Run that skill now with the same arguments.


### PR DESCRIPTION
## Summary
- Creates skills/dictate-daydream/SKILL.md as a thin redirect to /daydream-dictation
- Either slash command now starts a session

## Test plan
- [ ] Run /dictate-daydream and verify it triggers the main skill