### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ Use `/dd-teach` to learn the process interactively, tailored to your experience 
 
 ### Install the plugin
 
+Clone the repo and note the path:
+
 ```bash
-claude plugin add Ecnassianer/daydream-dictation
+git clone https://github.com/Ecnassianer/daydream-dictation.git
+```
+
+Then in Claude Code, install it as a local plugin:
+
+```
+/plugin install /path/to/daydream-dictation
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use `/dd-teach` to learn the process interactively, tailored to your experience 
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/code) (CLI, desktop app, or IDE extension)
-- Python 3.10+
+- Python 3.9+
 - Git (or another supported VCS)
 
 ### Install the plugin

--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# Daydream Dictation
+
+A Claude Code plugin for voice-driven document authoring. Talk out loud about your ideas and let Claude organize them into well-structured design documents.
+
+## How It Works
+
+Daydream Dictation uses a three-phase workflow:
+
+1. **Structured Daydreaming** -- Talk freely about your idea for 20-60 minutes. Don't edit, don't review. Claude captures and organizes everything as you speak.
+2. **Response & Engagement** -- Read through Claude's responses, answer questions, fill gaps. Run a gap analysis to check completeness.
+3. **Diff Review** -- Review the pull request diff, leave feedback, and merge when satisfied.
+
+Use `/dd-teach` to learn the process interactively, tailored to your experience level.
+
+## Installation
+
+### Prerequisites
+
+- [Claude Code](https://claude.ai/code) (CLI, desktop app, or IDE extension)
+- Python 3.10+
+- Git (or another supported VCS)
+
+### Install the plugin
+
+```bash
+claude plugin add Ecnassianer/daydream-dictation
+```
+
+## Usage
+
+### Start a session
+
+```
+/daydream-dictation "My Project Name"
+```
+
+Or use the alias `/dictate-daydream`.
+
+This creates the project folder and files if they don't exist, sets it as the active project, and begins the session.
+
+### Run a gap analysis
+
+```
+/dd-gap-analysis
+```
+
+Analyzes the current project's documents for missing coverage, open TODOs, and implementation gaps.
+
+### Learn the process
+
+```
+/dd-teach
+```
+
+Interactive onboarding that explains the three phases, voice dictation tips, and version control for the review cycle.
+
+## Project Structure
+
+Each project gets a folder with three documents:
+
+- `Daydream-<Slug>.md` -- The main design document
+- `TODO-<Slug>.md` -- Outstanding work items
+- `Prompts-<Slug>.md` -- Verbatim log of every voice prompt
+
+Optional companion documents (`TechDesign-`, `StringTable-`, `DebugTools-`) can be added as a project grows.
+
+## Hooks
+
+The plugin includes two hooks that fire automatically:
+
+- **UserPromptSubmit** -- Logs every prompt to the active project's Prompts document
+- **Stop** -- Checks for uncommitted or unpushed changes before Claude stops responding
+
+## Supported VCS
+
+- Git (first-class, default)
+- Mercurial
+- Perforce
+- Unity VCS / Plastic SCM
+
+Override auto-detection by creating `.claude/dd-vcs` with the VCS name.
+
+## Voice Variants
+
+Create `.claude/dd-voice-variants.md` in your repo to list words your dictation software commonly confuses. See `skills/daydream-dictation/example-voice-variants.md` for the format.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Installation instructions (claude plugin add)
- Prerequisites (Python 3.10+, Git)
- Usage for all three skills (/daydream-dictation, /dd-gap-analysis, /dd-teach)
- Project structure, hooks, VCS support, voice variants

## Test plan
- [ ] Review content for accuracy
- [ ] Verify install command is correct