### PR TITLE
Reference example-voice-variants and remove stale test comment

### DIFF
--- a/skills/daydream-dictation/SKILL.md
+++ b/skills/daydream-dictation/SKILL.md
@@ -38,7 +38,7 @@ When the user tells you which project to work on:
    python3 ${CLAUDE_PLUGIN_ROOT}/scripts/dd_switch_project.py "ProjectSlug"
    ```
    For new projects, use `dd_init_project.py` instead (it switches automatically after creation).
-2. **Load commonly confused words** — check for variant files in `.claude/` (e.g., `.claude/dd-voice-variants.md`). If found, familiarize yourself with the substitutions so you can apply them throughout the session.
+2. **Load commonly confused words** — check for variant files in `.claude/` (e.g., `.claude/dd-voice-variants.md`). If found, familiarize yourself with the substitutions so you can apply them throughout the session. See `${CLAUDE_SKILL_DIR}/example-voice-variants.md` for the expected format.
 3. **Read the tail of the Prompts document** — last 20–30 entries. Do not read the entire file; it can be very long.
 4. **Read the entire Daydream document** - this is the canonical central text for everything we're working on.
 5. **Take note of any other documents referenced in the Daydream document** - more complex designs will spin off specialized docs. Make sure you understand what things go in which document, but you don't have to read each one until its relevant.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,6 @@
 """
 tests/test_integration.py — Integration tests for scripts and hooks.
 
-Covers gaps from TestPlan-DaydreamDictationSkill.md Sections 5, 6, and 8
-that aren't covered by unit tests in test_dd_lib.py.
-
 Run with:
     cd <plugin-root>
     python3 -m pytest tests/test_integration.py -v


### PR DESCRIPTION
## Summary
- SKILL.md now points to example-voice-variants.md when describing the voice variants feature
- Removed reference to TestPlan-DaydreamDictationSkill.md (lives in a different repo) from test_integration.py docstring

## Test plan
- [ ] Verify changes read correctly in context