### PR TITLE
fix: create Prompts file on first prompt when project is set but file…

### DIFF
--- a/hooks/dd_log_prompt.py
+++ b/hooks/dd_log_prompt.py
@@ -66,9 +66,18 @@ def main() -> None:
         with open(state_file, encoding="utf-8") as f:
             project_folder = f.read().strip()
         if project_folder:
+            # Project is set — always route here, creating the Prompts file if needed
             matches = sorted(glob_module.glob(os.path.join(project_folder, "Prompts-*")))
             if matches:
                 prompts_doc = matches[0]
+            else:
+                # Derive slug from folder name and create the Prompts file
+                slug = os.path.basename(project_folder.rstrip("/"))
+                prompts_doc = os.path.join(project_folder, f"Prompts-{slug}.md")
+                os.makedirs(project_folder, exist_ok=True)
+                if not os.path.isfile(prompts_doc):
+                    with open(prompts_doc, "w", encoding="utf-8") as f:
+                        f.write(f"# Prompts \u2014 {slug}\n\n---\n\n")
 
     if prompts_doc is None:
         prompts_doc = os.path.join(repo_root, "Prompts-ddMetadiscussion")


### PR DESCRIPTION
… doesn't exist yet

Without this, a newly-set project with no Prompts-* file would fall through to Prompts-ddMetadiscussion instead of routing to the correct project file.