### PR TITLE
feat: add marketplace.json for plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "daydream-dictation",
+  "owner": {
+    "name": "Ecnassianer",
+    "email": "github.com/Ecnassianer"
+  },
+  "metadata": {
+    "description": "Voice-driven document authoring plugin for Claude Code. Structured daydreaming, interactive engagement, and diff review."
+  },
+  "plugins": [
+    {
+      "name": "daydream-dictation",
+      "source": {
+        "source": "github",
+        "repo": "Ecnassianer/daydream-dictation"
+      },
+      "description": "Voice-driven document authoring with a three-phase workflow: structured daydreaming, interactive engagement, and diff review.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Ecnassianer"
+      },
+      "homepage": "https://github.com/Ecnassianer/daydream-dictation",
+      "repository": "https://github.com/Ecnassianer/daydream-dictation",
+      "license": "MIT",
+      "keywords": ["dictation", "voice", "design-docs", "daydream"],
+      "category": "productivity"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` so this repo can serve as a Claude Code plugin marketplace, enabling direct installation via the marketplace system.

Once merged, users can install the plugin with:

```
/plugin marketplace add Ecnassianer/daydream-dictation
/plugin install daydream-dictation@daydream-dictation
```

## What changed

- Added `.claude-plugin/marketplace.json` listing the `daydream-dictation` plugin, sourced from this repo on GitHub

## Test plan

- [ ] `/plugin marketplace add Ecnassianer/daydream-dictation` succeeds
- [ ] `/plugin install daydream-dictation@daydream-dictation` installs the plugin
- [ ] Skills (`/daydream-dictation`, `/dd-teach`, `/dd-gap-analysis`) are available after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)