### PR TITLE
fix: instruct Claude not to open duplicate PRs after pushing

### DIFF
--- a/hooks/dd_stop_hook.py
+++ b/hooks/dd_stop_hook.py
@@ -76,7 +76,8 @@ def check_git(repo_root: str) -> None:
         if unpushed > 0:
             print(
                 f"There are {unpushed} unpushed commit(s) on branch '{current_branch}'. "
-                "Please push these changes to the remote repository.",
+                "Please push these changes to the remote repository. "
+                "Do not create a new PR unless the existing PR has already been merged or the user asks for one.",
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -90,7 +91,8 @@ def check_git(repo_root: str) -> None:
         if unpushed > 0:
             print(
                 f"Branch '{current_branch}' has {unpushed} unpushed commit(s) "
-                "and no remote branch. Please push these changes to the remote repository.",
+                "and no remote branch. Please push these changes to the remote repository. "
+                "Do not create a new PR unless the existing PR has already been merged or the user asks for one.",
                 file=sys.stderr,
             )
             sys.exit(2)


### PR DESCRIPTION
## Summary

The stop hook's unpushed-commit messages now tell Claude not to create a new PR if one already exists for the branch.

Previously, after pushing, Claude would often immediately open a PR even when one was already open. The added sentence gives Claude explicit guidance to check first.

## Test plan

- [ ] Push commits on a branch that already has an open PR — Claude should push only, not open a second PR
- [ ] Push commits on a branch with no open PR — Claude should push and open a PR as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)