### PR TITLE
docs: expand installation section with all three methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,101 @@ Use `/dd-teach` to learn the process interactively, tailored to your experience 
 
 ### Prerequisites
 
-- [Claude Code](https://claude.ai/code) (CLI, desktop app, or IDE extension)
 - Python 3.9+
 - Git (or another supported VCS)
 
-### Install the plugin
+There are three installation methods depending on how you run Claude Code.
 
-Clone the repo:
+---
 
-```bash
-git clone https://github.com/Ecnassianer/daydream-dictation.git
+### Method 1 — Claude Code CLI
+
+Run these commands inside Claude Code:
+
+```shell
+/plugin marketplace add ecnassianer/daydream-dictation
+/plugin install daydream-dictation@daydream-dictation
+/reload-plugins
 ```
 
-Then add it to your Claude Code settings. Edit `~/.claude/settings.json` (or `.claude/settings.json` in your project):
+---
+
+### Method 2 — Claude Code Desktop (local or SSH sessions)
+
+The Desktop app supports plugins for local and SSH sessions (not remote sessions).
+
+1. Click **Customize** in the left sidebar.
+2. Next to **Personal plugins**, click the **+** button, then select **Create plugin > Add marketplace**.
+3. In the **Add marketplace** dialog, enter `ecnassianer/daydream-dictation` and click **Sync**.
+4. Click **+** next to Personal plugins again, then select **Browse plugins**.
+5. Open the **Personal** tab, find the **Daydream Dictation** tile, and click **+** to install it.
+
+---
+
+### Method 3 — Claude Code Cloud or manual install
+
+Claude.ai/code (remote cloud sessions) does not support the plugin system. Install manually instead.
+
+**Step 1 — Clone the plugin into your repo:**
+
+```bash
+git clone https://github.com/Ecnassianer/daydream-dictation.git DaydreamDictationSkill/CompletedSkill
+```
+
+**Step 2 — Wire up hooks in `.claude/settings.json`:**
 
 ```json
 {
-  "extraKnownMarketplaces": {
-    "local-plugins": {
-      "source": {
-        "source": "directory",
-        "path": "/absolute/path/to/daydream-dictation"
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 DaydreamDictationSkill/CompletedSkill/hooks/dd_log_prompt.py",
+            "timeout": 10
+          }
+        ]
       }
-    }
-  },
-  "enabledPlugins": {
-    "daydream-dictation@local-plugins": true
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 DaydreamDictationSkill/CompletedSkill/hooks/dd_stop_hook.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
   }
 }
 ```
 
-Replace `/absolute/path/to/daydream-dictation` with the actual path where you cloned the repo. Restart Claude Code to load the plugin.
+If you already have other settings in this file, merge the `hooks` key in — don't replace the whole file.
+
+**Step 3 — Reference the skills in `CLAUDE.md`:**
+
+```markdown
+## Daydream Dictation Skills (manually installed)
+
+The following skills are available. Read the referenced SKILL.md file when invoked:
+
+- **daydream-dictation** — Main workflow skill. See `DaydreamDictationSkill/CompletedSkill/skills/daydream-dictation/SKILL.md`
+- **dd-gap-analysis** — Gap analysis skill. See `DaydreamDictationSkill/CompletedSkill/skills/dd-gap-analysis/SKILL.md`
+- **dd-teach** — Interactive onboarding. See `DaydreamDictationSkill/CompletedSkill/skills/dd-teach/SKILL.md`
+- **dictate-daydream** — Alias for daydream-dictation. See `DaydreamDictationSkill/CompletedSkill/skills/dictate-daydream/SKILL.md`
+
+When the user invokes any of these skills, read the corresponding SKILL.md and follow its instructions.
+
+## Utility Scripts
+
+- `dd_init_project.py` — Create a new project: `python3 DaydreamDictationSkill/CompletedSkill/scripts/dd_init_project.py "Project Name"`
+- `dd_switch_project.py` — Switch active project: `python3 DaydreamDictationSkill/CompletedSkill/scripts/dd_switch_project.py "ProjectSlug"`
+```
+
+After updating `settings.json`, run `/hooks` or start a new session to activate the hooks.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,34 @@ When the user invokes any of these skills, read the corresponding SKILL.md and f
 - `dd_switch_project.py` — Switch active project: `python3 DaydreamDictationSkill/CompletedSkill/scripts/dd_switch_project.py "ProjectSlug"`
 ```
 
-After updating `settings.json`, run `/hooks` or start a new session to activate the hooks.
+**Step 4 — Fix tests for cloud environments (optional):**
+
+Cloud environments often have `commit.gpgsign=true` set globally, which causes the integration tests to fail. To fix this, add the following line to both `_make_git_repo()` and `_make_git_repo_with_remote()` in `tests/test_integration.py`, immediately after the `git config user.name` line:
+
+```python
+subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=tmpdir, capture_output=True)
+```
+
+For `_make_git_repo_with_remote()`, use `cwd=work` instead of `cwd=tmpdir`. Then run:
+
+```shell
+cd DaydreamDictationSkill/CompletedSkill
+pip install pytest
+python3 -m pytest tests/ -v
+```
+
+All 75 tests should pass.
+
+**Step 5 — Verify hooks are active:**
+
+After updating `settings.json`, run `/hooks` or start a new session to activate the hooks. To confirm the `UserPromptSubmit` hook is working, type a message and check that it appears in `Prompts-ddMetadiscussion` (or your active project's Prompts file).
+
+**What you get:**
+
+- **Prompt logging** — Every message is automatically appended to the active project's Prompts document
+- **Stop guard** — Claude won't stop until all changes are committed and pushed
+- **Skills** — `daydream-dictation`, `dd-gap-analysis`, `dd-teach`, and `dictate-daydream` are all available via CLAUDE.md references
+- **Project management** — `dd_init_project.py` and `dd_switch_project.py` work identically to the plugin version
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Replaces the outdated single-method installation section with all three supported methods:

1. **CLI** — `/plugin marketplace add` + `/plugin install` + `/reload-plugins`
2. **Desktop** — step-by-step GUI walkthrough (Customize → Add marketplace → Browse plugins)
3. **Cloud / manual** — clone + `settings.json` hooks + `CLAUDE.md` skill references

## Test plan

- [ ] Read through each method and verify the commands/steps are accurate
- [ ] Check that the `settings.json` JSON in Method 3 is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)