### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "repo": "Ecnassianer/daydream-dictation"
       },
       "description": "Voice-driven document authoring with a three-phase workflow: structured daydreaming, interactive engagement, and diff review.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Ecnassianer"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "daydream-dictation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Voice-driven document authoring with a three-phase workflow: structured daydreaming, interactive engagement, and diff review.",
   "author": {
     "name": "Ecnassianer",


### PR DESCRIPTION
## Summary

Bumps plugin version from 0.1.0 to 0.2.0 in both `plugin.json` and `marketplace.json`.

**Changes since 0.1.0:**
- fix: create Prompts file on first prompt when project is set (#26)
- fix: stop hook no longer triggers duplicate PRs (#28)
- feat: add marketplace.json for plugin distribution (#27)
- docs: expand README with all three installation methods (#29)

## Test plan

- [ ] `plugin.json` and `marketplace.json` both show `0.2.0`
- [ ] `/plugin marketplace update` picks up the new version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)