### PR TITLE
Release v0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "repo": "Ecnassianer/daydream-dictation"
       },
       "description": "Voice-driven document authoring with a three-phase workflow: structured daydreaming, interactive engagement, and diff review.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Ecnassianer"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "daydream-dictation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Voice-driven document authoring with a three-phase workflow: structured daydreaming, interactive engagement, and diff review.",
   "author": {
     "name": "Ecnassianer",


### PR DESCRIPTION
## Summary
- Bumps plugin version to 0.2.1
- Includes fixes merged since v0.2.0:
  - Rename TDD/TechDesign → Decision Trace (#25)
  - Fix stale state fallback in `dd_log_prompt.py`
  - Add legacy rename rule for `TechDesign-`/`TDD-` files
  - Add test for Prompts file creation when missing (PR #26 coverage)

## Test plan
- [ ] All 76 tests pass
- [ ] Version reads 0.2.1 in both plugin.json and marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)