### PR TITLE
dd-teach: iterative improvements + description-eval harness

### DIFF
--- a/skills/dd-teach/SKILL.md
+++ b/skills/dd-teach/SKILL.md
@@ -18,13 +18,66 @@ When the user asks "how does this work?" or similar, start with this:
 
 **Daydream Dictation** is a three-phase workflow for building documents with an AI using voice input.
 
-**Phase 1 — Structured Daydreaming.** Plan for a focused creative session of 20–60 minutes. Set a timer if it helps. Talk out loud about your idea. Don't edit, don't review, don't look at what the AI is writing. Just generate. The AI captures everything and organizes it into the document as you go. Trust your voice dictation and the AI. Your only job is to keep your creative momentum going.
+**Phase 1 — Structured Daydreaming.** Talk out loud about your idea. Don't edit, don't review, don't look at what the AI is writing — just generate. The AI captures everything and organizes it into the document as you go. You're done when new ideas dry up, your energy dips, or you genuinely want to see what you made. That's usually around 20–60 minutes. Stopping earlier (after 5–10 minutes to "check the work") almost always means you haven't actually dropped into the creative headspace yet — the real payoff comes from staying with it past that urge. When you're done, come back and the AI will walk you through Phase 2.
 
-**Phase 2 — Response and Agent Engagement.** Now engage with the AI. Read through its replies from Phase 1 top to bottom, answer its questions, fill in gaps, and add anything that comes up. Then ask for a gap analysis — a structured check to surface what's missing and what to-dos are still open. This phase has much lower focus requirements than Phase 1; it works well even when you're tired or interrupted.
+**Phase 2 — Response and Agent Engagement.** This is its own kind of thinking, not just a bridge between the other two. Phase 1 leaves gaps by design; Phase 2 is how you close them. Read through the AI's replies, answer its questions, add what's missing. Ask for a gap analysis — a structured check that surfaces holes, contradictions, and open to-dos. The AI is a sounding board and a foil here: it reflects the idea back, names what doesn't hang together, and you refine against that pushback until the work becomes cohesive. It's problem-finding and structural troubleshooting, not detail-level fact-checking (that's Phase 3). Lower focus than Phase 1; works well even when you're tired or interrupted.
 
 **Phase 3 — Diff Review.** Check the pull request (or your version control diff view) and read what actually changed. This is where you catch mistakes, transcription errors, and misunderstandings. Leave inline comments on the diff with feedback, then bring them to the AI as a batch. When you're satisfied, approve and merge. This step is what makes Phase 1 safe — knowing you'll verify everything later is what lets you trust the process and stay in the creative flow.
 
-Phases don't have to happen in a single pass. It's normal to cycle through all three more than once on the same document. After merging, start a new session — the Prompts document captures everything the next session needs to pick up where you left off.
+Phases don't have to happen in a single pass. It's normal to cycle through all three more than once on the same document. After merging, start a new session — the Daydream document itself is what the next session picks up from. The Prompts document is your audit trail, kept so you can trace what dictation caused which change, not a handoff mechanism.
+
+---
+
+## Onboarding a First-Time User: Logistics, Not Content
+
+When teaching the workflow to a new user who's about to start their first session, stay on **logistics**, not the content of their project. It's tempting to ask "what's your memo about, roughly?" or "what are the main topics?" as part of setup — these feel helpful but they are Phase 1 content under a setup label, and once the user starts answering, the session boundary is gone.
+
+Setup questions to ask:
+- What should we call the project? (so `/daydream-dictation` can create the folder)
+- Do you have a good voice dictation tool installed?
+- Where are you planning to do Phase 1 — walking, at a desk, phone, etc.?
+
+Do **not** ask about git or version control familiarity during onboarding. Phase 1 doesn't require any git knowledge — the agent handles all of it. When the user reaches Phase 3 and actually needs to look at a diff, that's the moment to calibrate explanation depth to their comfort level. Bringing it up earlier just adds to the intimidation and delays the user getting started.
+
+Questions to avoid before the session starts:
+- What's the document about? What are the main themes? What's your thesis?
+- Who's the audience?
+- What sections are you imagining?
+
+Those are Phase 1 material. Let them come out of the user's own dictation, captured fresh, not pulled out by the agent during onboarding. When the user is ready, hand them off to `/daydream-dictation` — that's the clean session boundary.
+
+**Just skip those questions silently.** Don't narrate the rule ("I'm deliberately not asking about the content of your memo because..."). The user doesn't need to know about the internal guideline — it reads as rule-following theater. Ask the logistics questions and leave out the rest without comment.
+
+**Ask the setup questions exactly once.** Don't list them inline and then repeat them as a trailing "unanswered questions" footer. One pass is enough; the user can read.
+
+---
+
+## Response Posture
+
+Teaching Daydream Dictation well means answering what the user actually asked, at the length they actually need — not delivering the whole manual every time.
+
+### Match Length to Urgency
+
+If the user is mid-action — "I'm ready to talk, what's step one?", "I'm in the middle of Phase 1 and glanced" — they need a short answer that gets them moving again. A 600-word response with section headers burns their momentum. Aim for: the one or two things they need to do next, a sentence of context if truly necessary, done. Deeper theory can wait until they come back.
+
+If the user is cold and asking "how does this work?", more depth is appropriate — but still don't dump the whole skill. Give the shape and an invitation to go deeper on what interests them.
+
+### Stay On the User's Question
+
+Answer the question they asked. Don't preemptively backfill adjacent topics they didn't ask about — and in particular, **don't pre-reassure them about concerns they haven't raised.** "You don't need to know git" sounds helpful, but if the user hasn't mentioned git, saying this plants the worry rather than soothing it. Only address git/version control when (a) the user brings it up, or (b) you're actually at the point of Phase 3 where they need to look at a diff.
+
+More generally:
+
+- A user asking how to start Phase 1 doesn't need an unsolicited git primer — git comes up at Phase 3.
+- A user asking "how does this work?" needs the shape of the workflow, not a list of things they *don't* have to worry about. If git is in the answer at all, it should be a one-line mention that the AI handles it, not a reassurance paragraph.
+- A user asking about Phase 1 discipline doesn't need the full Phase 2/3 walkthrough — mention they exist as the safety net and leave it at that.
+- A user asking about version control anxiety doesn't need a tour of voice dictation tools.
+
+Related context can come up when it's actually relevant to their next move. Mention it in a sentence if needed, but don't build out unsolicited sections around it, and don't volunteer reassurances about concerns the user hasn't voiced.
+
+### Teach Responses Are Not Plans
+
+If the ambient project convention is to append an "unanswered questions" or "open questions" footer to plans, that convention does not apply to teach responses. Teach responses are dialogue — if you need an answer from the user, ask it once, in the natural place in the body. Don't stack a plan-style question footer at the end.
 
 ---
 
@@ -47,18 +100,55 @@ Topics don't need to go in order. Useful moves:
 - Spin off tasks for the AI to handle async: "Make a subagent to fill in a tide levels table for each city in the document"
 - Don't design the document while filling it — brief structural notes are fine, but organization is the AI's job
 
+### Teach One Phase at a Time
+
+For a brand-new user, don't deliver the whole workflow in one lecture. Teach Phase 1 well, point to the fact that Phase 2 and Phase 3 exist as the safety net, then stop. The natural handoff is the Phase 1 stopping signal itself: "when your ideas dry up or your energy dips, come back and I'll walk you through Phase 2." That's where they learn it, when it's actually useful.
+
+The full three-phase overview is appropriate when someone is asking "how does this work?" from outside — they want the shape of the thing. When someone is mid-action ("I'm ready to start"), skip the overview and get them dictating.
+
+### Physical Configuration by Phase
+
+Each phase has a natural physical configuration, and the research supports the mapping:
+
+- **Phase 1 (generative):** walking, pacing, or otherwise in motion. Free movement measurably boosts divergent thinking (Oppezzo & Schwartz 2014 found ~60% more ideas while walking; mild movement loosens top-down attentional control). Outside, a park, a hallway — whatever keeps the body moving and the mind roaming.
+- **Phase 2 (refining/troubleshooting):** stationary and comfortable — a couch, a comfy chair, phone in hand. Mid-load, interruption-tolerant. You're reading a few paragraphs, replying, repeating — working through problems the AI surfaces. Big screen not needed.
+- **Phase 3 (detail review):** upright at a desk, ideally with a large screen or multiple monitors. You're scanning a long diff and holding lots of context in working memory. Upright posture supports analytical focus (Peper 2017, Riskind & Gotay 1982); larger displays measurably help comprehension tasks that span many regions (Czerwinski 2003, Ball & North 2005); and high-working-memory tasks are substantially more interruption-sensitive than generative ones (Monk, Trafton & Boehm-Davis 2008), so protect the session.
+
+These are optimizations, not requirements. If someone has to do Phase 1 at a desk because that's what's available, it still works. But when a user asks where to do which phase, this is the answer.
+
+### Submit in Bite-Sized Chunks
+Don't try to deliver a 30-minute monologue as one giant prompt. Each natural pause is a good submission point — submit every minute or two, or whenever you finish a thought. Most voice dictation tools handle this automatically when you pause.
+
+Shorter prompts matter because:
+- The AI can organize content into the document incrementally, instead of trying to parse a wall of text at the end
+- The Prompts document stays readable — one topic per entry, which makes Phase 3 review much easier
+- If something goes wrong in one prompt (bad dictation, AI confusion), it's contained
+
+A loose rule of thumb: if you're going to talk for more than ~3 minutes on one topic without pausing, you're probably building toward a prompt that'll be hard to review later.
+
 ### Environment and Body Position
 - Somewhere free from distractions — **outside walking**, **a park**, **near the ocean**, or **a quiet room**
 - Physical position matters: seated, pacing, walking all work. Follow what the body wants
 - Protect the creative window — a single interruption costs 5–10 minutes of re-entry
-- Phase 1 works especially well from a smartphone — treat the device as a microphone, not a productivity station
+- Phase 1 works especially well from a smartphone — your voice is the only input that matters, so you can roam while dictating. The device still needs to be accessible enough to operate the dictation software (starting it, seeing that it's capturing, submitting prompts) — so holding it or keeping it in sight is fine. The point is you don't have to be tethered to a desk or monitor.
 
-### Keep Eyes Off the Screen
-Look at the sky, the room, the world — anywhere but the screen. The AI's responses are not for the user right now; reading them pulls out of the creative headspace into analytical mode. If struggling, try closing eyes entirely while dictating.
+### When the User Keeps Glancing at the Screen
 
-Let the mind disengage from the recording process and stay in **generative thought**.
+The natural urge to check what the AI is writing is almost always a **trust problem**, not a discipline problem. Don't just tell them "don't look" — find out what they're actually checking for, then address it.
 
-If absolutely necessary, record prompts in a separate document and paste them in as a batch. This is a last resort — it breaks the natural commit sequence and makes Phase 3 review harder. But it's valid for buffering thoughts when rate-limited or unable to focus.
+Ask them what's pulling their eyes back. It's usually one of:
+
+- **Dictation quality.** They don't trust what got captured. *Fix:* if the dictation software is genuinely mishearing whole sentences, they need a better tool (e.g., [Wispr Flow](https://wisprflow.ai/)) — no amount of discipline overcomes unreliable input. A few mispoken words are fine; the AI handles that.
+- **AI drift.** They're worried the AI is going off the rails and they'll have to redo work. *Fix:* reassure them that every prompt is logged verbatim in the Prompts document, so nothing is ever lost. Any misinterpretation gets caught in Phase 2 (when they read the AI's replies) or Phase 3 (when they see the diff). There is no "point of no return" in Phase 1.
+- **Wanting acknowledgment.** They want to feel heard — to see the AI responding to each thing. *Fix:* name this honestly. The AI is listening, but Phase 1 deliberately postpones the back-and-forth so the user can stay in generative mode. That acknowledgment comes in Phase 2.
+
+If the user is new to the workflow, their trust hasn't been earned yet — it gets built by cycling through Phase 2 and Phase 3 a few times and seeing that the process genuinely catches problems. Encourage them to finish a full cycle even if Phase 1 felt rough; the trust compounds.
+
+Where to point your attention is personal — eyes closed, looking out a window, pacing. The one thing to avoid is **reading the AI's replies** while you're dictating. Glancing at the screen to operate the dictation software (start it, confirm it's capturing, submit a prompt) is just using a tool — that's not what breaks Phase 1. Reading the generated text is what flips your brain out of generative mode into analytical mode, and once you're there it's hard to get back.
+
+### Last Resort: Record Prompts Separately
+
+If absolutely necessary — rate-limited, can't focus — record prompts in a separate document and paste them in as a batch. This breaks the natural commit sequence and makes Phase 3 review harder, but it's valid for buffering thoughts.
 
 ### Source Material
 The concept of structured daydreaming as a creative practice has prior art. Ray Mazza's article [Structured Daydreaming](https://www.raymazza.com/post/structured-daydreaming) is the direct inspiration for Phase 1.
@@ -68,6 +158,9 @@ The concept of structured daydreaming as a creative practice has prior art. Ray 
 ## Phase 2 Guidance
 
 When the user asks for help with Phase 2:
+
+### What Phase 2 Actually Is
+Phase 2 is its own cognitive mode — refining, troubleshooting, structural problem-solving. Phase 1 produced a lot of material with deliberate gaps; Phase 2 is where those gaps get closed and the thing becomes cohesive. The AI is a foil here: it asks questions, points out contradictions, surfaces what's missing through gap analysis, and the user refines against that pushback. It's social in a way — a dialogue, not a monologue — and the friction is the point. Don't confuse it with Phase 3: Phase 2 is about structure and holes, not fact-checking at the sentence level.
 
 ### How to Start
 Begin at the top of the AI's replies from Phase 1 and work down. Address questions, fill gaps, add details. If something sparks a new idea, add it. Work through the whole list before asking for the gap analysis.
@@ -107,7 +200,13 @@ If the user is unfamiliar with diffs or version control, walk them through it st
 The Prompts document is the reference for understanding what caused any change.
 
 ### Leaving Feedback
-Leave inline comments on the diff, then tell the AI: "Go address the comments on the PR." Or give the AI feedback directly. After the AI makes corrections, jump to the most recent commits to verify fixes.
+
+Phase 3 does require the user to touch the PR page for two things: **reading the diff** (that's where the before/after view lives) and **approving/merging** at the end. What's optional is the *feedback mechanism* in the middle — there are two ways:
+
+- **Just talk to the AI.** Dictate what you want changed: "the Networking section has it backwards, clients should connect to the server not the other way around." The AI makes the edit, commits, and pushes. No need to learn the GitHub inline-comment UI. This is the right default for anyone who finds the PR comment interface intimidating or awkward.
+- **Inline comments on the diff.** If the user is comfortable with GitHub (or their VCS equivalent), leaving inline comments is nice for capturing a batch of feedback at once, then saying: "Go address the comments on the PR." Each comment becomes its own fix.
+
+Both paths land in the same PR. Mix and match freely. After the AI makes corrections, jump to the most recent commits on the PR to verify the fixes, then approve and merge.
 
 ### Approve and Merge
 When satisfied, approve and merge the pull request. Don't skip this — without a merge, work can appear lost. If the user feels lost with version control, guide them through it.
@@ -128,7 +227,7 @@ When the user asks about when to end or start sessions:
 - A single objective spans several phase cycles and will be reviewed/merged together
 - Mid-phase and context is still clean
 
-The end of Phase 3, right after merging, is almost always a good time to close. The Prompts document makes handoffs cheap — a new session reads the tail and picks up where the last left off.
+The end of Phase 3, right after merging, is almost always a good time to close. The Daydream document is the authoritative state — a new session reads it and takes it from there.
 
 ## Cycling Through Phases
 

--- a/skills/dd-teach/SKILL.md
+++ b/skills/dd-teach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-teach
-description: Explains the Daydream Dictation process to users. Activates when the user asks how to use Daydream Dictation, asks about the three phases, wants tips for dictation sessions, asks what they should be doing, or needs help with version control during the review cycle.
+description: Explains the Daydream Dictation process to users. Activates when the user asks how to use Daydream Dictation, asks about the three phases, wants tips for Daydream Dictation sessions, asks what they should be doing in the workflow, or needs help with version control during the review cycle. Does not activate for general voice-typing or dictation-tool questions (e.g. comparing Wispr Flow to built-in voice typing) — those are tooling questions, not workflow questions.
 version: 0.1.0
 ---
 

--- a/skills/dd-teach/SKILL.md
+++ b/skills/dd-teach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dd-teach
-description: Explains the Daydream Dictation process to users. Activates when the user asks how to use Daydream Dictation, asks about the three phases, wants tips for Daydream Dictation sessions, asks what they should be doing in the workflow, or needs help with version control during the review cycle. Does not activate for general voice-typing or dictation-tool questions (e.g. comparing Wispr Flow to built-in voice typing) — those are tooling questions, not workflow questions.
+description: Explains the Daydream Dictation process to users. Activates when the user asks how to use Daydream Dictation, asks about the three phases, wants tips for dictation sessions, asks what they should be doing in the workflow, or needs help with version control during the review cycle. Does not activate for general voice-typing or dictation-tool questions (e.g. comparing Wispr Flow to built-in voice typing) — those are tooling questions, not workflow questions.
 version: 0.1.0
 ---
 

--- a/tests/description-eval/README.md
+++ b/tests/description-eval/README.md
@@ -1,0 +1,58 @@
+# dd-teach Description Eval
+
+Trigger evaluation for the `dd-teach` skill description. Tests whether realistic user queries cause Claude to invoke the skill at the expected rate, while leaving alone the queries that should be handled some other way.
+
+## Why this lives here, not in skill-creator
+
+`skill-creator`'s `scripts/run_eval.py` works by writing a temporary slash command into `.claude/commands/` and watching for Claude to invoke it. If the real `daydream-dictation:dd-teach` plugin skill is also installed in the same environment, Claude routes the trigger to the real skill instead of the temp command, and the eval reports false-negative 0-hits. To get an honest signal you need to run this in an environment where dd-teach is **not** installed as a plugin.
+
+## What's here
+
+- `run_eval.py` — vendored copy of skill-creator's evaluator, with `parse_skill_md` inlined so it's a single file
+- `trigger-eval.json` — 21 realistic queries (10 should-trigger, 11 should-not), tuned for the target audience: writers, designers, PMs, grant writers, policy folks, civil servants
+- `README.md` — this file
+
+## How to run
+
+In a Claude Code environment where `dd-teach` is **not** installed (a fresh cloud workspace, a clean Claude Code session on another machine, etc.):
+
+1. Clone or upload this folder somewhere accessible
+2. Put a copy of the `dd-teach` skill directory somewhere accessible too — you'll point the eval at it via `--skill-path`. The skill needs at minimum its `SKILL.md` (the eval reads the description from frontmatter unless you override).
+3. Run:
+
+```bash
+python run_eval.py \
+  --skill-path /path/to/dd-teach \
+  --runs-per-query 3 \
+  --num-workers 10 \
+  --verbose
+```
+
+Output: per-query pass/fail printed to stderr, full JSON results to stdout. Redirect stdout to a file if you want to keep it.
+
+### Override the description without editing SKILL.md
+
+Pass `--description "..."` to test a candidate description without modifying the skill file:
+
+```bash
+python run_eval.py \
+  --skill-path /path/to/dd-teach \
+  --description "Use this skill whenever the user mentions ..." \
+  --verbose
+```
+
+This is the fast way to A/B candidate descriptions during optimization.
+
+## What "pass" means
+
+Each query has a `should_trigger` flag. The eval runs the query through `claude -p` `runs-per-query` times and computes the trigger rate. Pass = trigger rate matches the expectation (above the threshold for `should_trigger: true`, below for `false`). Default threshold is 0.5.
+
+## Interpreting results
+
+- All should-trigger fail with 0/N triggers → the description isn't reaching Claude's "use a skill" decision point. Make it pushier (the skill-creator guide recommends explicit "use this skill any time..." phrasing).
+- All should-not-trigger pass with 0/N → the description isn't pulling on adjacent topics. Good signal, but check that the should-trigger ones are firing too — otherwise the skill is just inert.
+- Mixed → look at the specific failing queries. They tell you what shape of language the description doesn't catch.
+
+## Updating the eval set
+
+Edit `trigger-eval.json` directly. Each entry is `{"query": "...", "should_trigger": true|false}`. Keep queries realistic — full sentences with personal context, casual phrasing, the kind of thing a real user types. The skill-creator guide has good advice on writing eval queries.

--- a/tests/description-eval/run_eval.py
+++ b/tests/description-eval/run_eval.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for the dd-teach skill description.
+
+Vendored copy of skill-creator's `scripts/run_eval.py`, with `parse_skill_md`
+inlined so the file is fully self-contained — drop it into a fresh Claude
+Code cloud environment and it runs without needing the rest of skill-creator.
+
+The point of running this in a clean environment is that the eval works by
+creating a temporary slash command in `.claude/commands/` and watching for
+Claude to invoke that exact command. If the real `daydream-dictation:dd-teach`
+plugin is also installed, Claude will route triggers to that one instead and
+the eval will see 0 hits — a false negative. So: run this where dd-teach is
+NOT already installed as a plugin.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text(encoding="utf-8")
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/."""
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered."""
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content, encoding="utf-8")
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for the dd-teach skill")
+    parser.add_argument("--eval-set", default="trigger-eval.json", help="Path to eval set JSON file (default: trigger-eval.json next to this script)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory containing SKILL.md")
+    parser.add_argument("--description", default=None, help="Override description to test (otherwise uses SKILL.md frontmatter)")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set_path = Path(args.eval_set)
+    if not eval_set_path.is_absolute() and not eval_set_path.exists():
+        eval_set_path = Path(__file__).parent / args.eval_set
+
+    eval_set = json.loads(eval_set_path.read_text(encoding="utf-8"))
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/description-eval/trigger-eval.json
+++ b/tests/description-eval/trigger-eval.json
@@ -1,0 +1,24 @@
+[
+  {"query": "Someone on our research team keeps raving about something called Daydream Dictation. What is it and how would I actually use it for policy briefs?", "should_trigger": true},
+  {"query": "Ok I just installed the plugin, Wispr Flow is running on my phone, and I'm outside. What do I actually do to start my first session for this grant application?", "should_trigger": true},
+  {"query": "I tried a dictation session for a zoning memo yesterday and I kept glancing at what you were writing. I lost my flow every time. How do I get past that?", "should_trigger": true},
+  {"query": "Why does this process have three phases? Can't I just have one long conversation with you like normal?", "should_trigger": true},
+  {"query": "I just finished about 40 minutes of talking through the campaign messaging document. What am I supposed to do now?", "should_trigger": true},
+  {"query": "I'm at this github pull request page you keep sending me. I have no idea what I'm looking at. Can you walk me through this phase?", "should_trigger": true},
+  {"query": "What's a gap analysis? My colleague mentioned I should run one on my grant narrative but I don't know what that does in this workflow.", "should_trigger": true},
+  {"query": "I keep getting lost in Phase 2. What am I actually trying to accomplish when I'm responding to your questions?", "should_trigger": true},
+  {"query": "I'm a policy writer and I'm totally new to any kind of AI-assisted workflow. How does this thing actually work, start to finish?", "should_trigger": true},
+  {"query": "I'm halfway through dictating to you about my zoning memo and I'm not sure if I should stop and read what you wrote or keep going. how do I know when to move on to the next phase?", "should_trigger": true},
+
+  {"query": "I'm starting my Phase 2 session now for the transportation grant proposal. Let's talk about the overall funding request and why this project matters.", "should_trigger": false},
+  {"query": "Add a section on stakeholder engagement to the zoning memo, it should cover the community workshops we held in March.", "should_trigger": false},
+  {"query": "Can you help me structure the executive summary for this RFP response? I have the content, just need help with the shape.", "should_trigger": false},
+  {"query": "Run a gap analysis on this campaign messaging document — I want to know what I'm missing before I send it to the comms director.", "should_trigger": false},
+  {"query": "Let's set up a new Daydream project called 'Parks Budget FY27'. I want to start working through the rationale for the aquatics expansion.", "should_trigger": false},
+  {"query": "How do I squash the last three commits on this branch? I want to consolidate them before I push.", "should_trigger": false},
+  {"query": "Can you install the wispr flow plugin for me? I'm having trouble getting it to work with my voice dictation setup.", "should_trigger": false},
+  {"query": "What's the best voice-to-text app for Mac right now? I'm tired of the built-in dictation being bad.", "should_trigger": false},
+  {"query": "How do skills work in Claude Code? Can I install a skill from a local directory without publishing it?", "should_trigger": false},
+  {"query": "I wrote up a draft memo on my own and I want your feedback on the argument structure. Nothing fancy, just read it and tell me what's weak.", "should_trigger": false},
+  {"query": "Do I really need Wispr Flow or can I get by with my laptop's built-in voice typing for these brainstorming sessions?", "should_trigger": false}
+]


### PR DESCRIPTION
## Summary

- **Iterative improvements to `dd-teach`** from six rounds of test-driven review (5 realistic prompts: cold beginner, mid-action grant writer, Phase 1 discipline, why-three-phases, VCS anxiety). Highlights: Phase 1 stopping signal frames around energy/curiosity (20–60 min becomes calibration), Phase 1 discipline reframed as trust not willpower, Phase 2 reframed as its own cognitive mode (refining/troubleshooting/social), new "Onboarding" + "Response Posture" sections, new "Submit in Bite-Sized Chunks" guidance, new "Physical Configuration by Phase" with research citations, Phase 3 "no GitHub UI" claim properly scoped.
- **New `tests/description-eval/` harness** — vendored single-file copy of skill-creator's `run_eval.py` plus a 21-query trigger eval set (10 should-trigger, 11 should-not). Includes a README explaining the shadowing-bug workaround (skill-creator's harness produces silent false-negative 0-trigger results when the skill being tested is already installed; run this harness in a fresh environment instead).

## Test plan

- [ ] Read through the diff on `skills/dd-teach/SKILL.md` and confirm the iteration changes match the review feedback
- [ ] Run `tests/description-eval/run_eval.py` against the skill in a clean Claude Code environment (where dd-teach is *not* installed) to validate trigger rates
- [ ] Spot-check that `dd-teach` triggers correctly on a few should-trigger queries via real `claude -p` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)