### PR TITLE
daydream-dictation: clarify the agent doesn't own the Prompts file

### DIFF
--- a/skills/daydream-dictation/SKILL.md
+++ b/skills/daydream-dictation/SKILL.md
@@ -39,10 +39,11 @@ When the user tells you which project to work on:
    ```
    For new projects, use `dd_init_project.py` instead (it switches automatically after creation).
 2. **Load commonly confused words** — check for variant files in `.claude/` (e.g., `.claude/dd-voice-variants.md`). If found, familiarize yourself with the substitutions so you can apply them throughout the session. See `${CLAUDE_SKILL_DIR}/example-voice-variants.md` for the expected format.
-3. **Read the tail of the Prompts document** — last 20–30 entries. Do not read the entire file; it can be very long.
-4. **Read the entire Daydream document** - this is the canonical central text for everything we're working on.
-5. **Take note of any other documents referenced in the Daydream document** - more complex designs will spin off specialized docs. Make sure you understand what things go in which document, but you don't have to read each one until its relevant.
-6. **Confirm the prompt logging hook is firing** — check whether new entries appear after the user's next prompt.
+3. **Read the entire Daydream document** — this is the canonical state of the project. Everything you need to pick up where the last session left off is here.
+4. **Take note of any other documents referenced in the Daydream document** — more complex designs will spin off specialized docs. Make sure you understand what things go in which document, but you don't have to read each one until it's relevant.
+5. **Confirm the prompt logging hook is firing** — check whether new entries appear after the user's next prompt.
+
+Don't routinely read the Prompts document. It's the user's audit trail, not your context source. Consult it only when you specifically need to trace a decision back to the dictation that produced it (mostly a Phase 3 move).
 
 ### The `dd-current-dictation-project` State File
 
@@ -66,7 +67,7 @@ Runs the session-start workflow:
 2. If no project is specified, ask the user which project they're working on
 3. If the project doesn't exist, run `dd_init_project.py` to create it
 4. Run `dd_switch_project.py` to set the active project (skip if `dd_init_project.py` just ran — it switches automatically)
-5. Read the tail of the Prompts document (last 20–30 entries)
+5. Read the Daydream document for project state
 6. Confirm the prompt logging hook is firing
 7. Tell the user you're ready — briefly remind them of the three phases if this seems like their first time
 
@@ -127,30 +128,21 @@ The user is reviewing the pull request diff. They may leave inline comments on t
 
 ## The Prompts Document
 
-Every project has a companion Prompts document (`Prompts-<Slug>.md`) that logs every prompt used during sessions. This is a permanent record.
+Every project has a companion Prompts document (`Prompts-<Slug>.md`). The `UserPromptSubmit` hook writes to it automatically — every prompt the user dictates gets appended verbatim. **The script owns this file. You don't.**
 
-### Rules
+You are not its custodian. You don't routinely read it, edit it, curate it, summarize it, or reorganize it. It exists for the user's benefit — an audit trail they can consult when they want to trace a design decision back to the dictation that caused it (especially during Phase 3 review).
 
-- **Never delete logged prompts**, even if they seem off-topic.
-- **Manually updating prompts**, if the user asks you to clean up the prompts doc, be conservative. For instance, if a prompt clearly belongs to a different project, move it — but never discard it entirely. 
-- **Prompts doc lists prompts verbatim**, transcription errors and all. The raw wording is part of the record.
-- **Session-opening prompts stay in `Prompts-ddMetadiscussion`** — the hook fires before you set `dd-current-dictation-project`, so the first prompt of any session is logged there. This is correct and intentional. Do not move it into the project's Prompts document.
-- **Co-commit rule:** Prompt log entries belong in the same commit as the document changes they accompany. Do not commit the Prompts doc ahead of the corresponding work.
+### When you DO act on the Prompts file
 
-### Why We Keep It
+A small set of exception cases:
 
-- **Reconstruction** — clarifies intent when the design doc is ambiguous
-- **Audit trail** — trace any line back to the prompt that produced it
-- **Session continuity** — new sessions read the Prompts doc to understand history
-- **Debugging AI edits** — identifies whether an instruction was ambiguous or misinterpreted
+- **Backfilling.** If the hook failed and prompt entries are missing, reconstruct them from conversation history in order, number sequentially from the last captured entry, commit with a note that entries were backfilled, and tell the user the logging is broken so they can investigate. If failures persist across sessions, suggest filing a bug on the plugin's GitHub repo.
+- **Merge conflict.** Two sessions occasionally collide on prompt numbers. The only firm rule: **don't lose any prompts.** Prefer chronological order if recoverable, but `57/57 → 57a/57b` or `57/57 → 57/58` are both acceptable. Don't split into two Prompts files for the same project.
+- **User-requested cleanup.** If the user explicitly asks you to tidy the file (e.g., "this prompt belongs in the Campfire project, move it"), be conservative — move, never discard. Verbatim wording is part of the record, transcription errors and all.
 
-### Backfilling Missed Prompts
+### Co-commit rule
 
-If prompts were not captured automatically, add them manually in order. Use the conversation history to reconstruct exact wording. Number sequentially from the last captured entry. Commit with a note that entries were backfilled. Immediately notify the user that something is wrong with the prompt logging. If hook failures persist across sessions, suggest reporting it as a bug on the skill's GitHub repo.
-
-### Handling merges
-
-Sometimes two sessions will attempt to use the same number and merging the prompts file becomes difficult. How you resolve this isn't particularly important as long as _none_ of the prompts are lost. If you can tell which prompts came before the others, go ahead and try to put them first, but it's no sweat if the numbering doesn't exactly match chronologically. Try to deduplicate prompt numbers if you can, but how you fix it (57/57 becomes 57/58, or 57/57 becomes 57a/57b) should use your best judgement. Don't try to make two Prompts files for the same project.
+When you commit document changes, the corresponding Prompts log entries belong in the same commit. Don't commit the Prompts doc ahead of the work it accompanies.
 
 ## The Daydream Document
 


### PR DESCRIPTION
**Stacked on top of #39.**

## Summary

The \`daydream-dictation\` skill currently fusses with the Prompts file as if the agent is its custodian — rules about never deleting entries, manually updating, reading the tail at session start, etc. In practice the \`UserPromptSubmit\` hook owns ongoing operation. The agent only needs to act on the file in three exception cases: backfilling, merge resolution, and user-requested cleanup.

## What changed

- **"The Prompts Document" section** rewritten to lead with the ownership boundary: _\"The script owns this file. You don't.\"_ Three exception cases listed explicitly (backfill / merge / user-requested cleanup), plus the co-commit rule.
- **Session start step 3** ("Read the tail of the Prompts document — last 20–30 entries") removed. Daydream document is the canonical project state; Prompts log is the user's audit trail, not the agent's context source.
- **Slash command step 5** ("Read the tail of the Prompts document") replaced with "Read the Daydream document for project state."
- Added a one-line note in the Starting a Session block: _\"Don't routinely read the Prompts document. It's the user's audit trail, not your context source. Consult it only when you specifically need to trace a decision back to the dictation that produced it (mostly a Phase 3 move).\"_

Net: -23 / +15 lines on \`skills/daydream-dictation/SKILL.md\`.

## Why now

Surfaced during dd-teach skill-creator iteration as relevant context, before starting the same review process on the daydream-dictation skill. Wanted the framing fix in place before generating test prompts that might otherwise reinforce the wrong mental model.

## Test plan

- [ ] Read the diff and confirm the new framing matches the intent (script owns; agent intervenes in exceptions only)
- [ ] Spot-check that no other parts of the skill still imply the agent should curate the Prompts file routinely

🤖 Generated with [Claude Code](https://claude.com/claude-code)